### PR TITLE
Added islegacytemplate flag to manifest to ensure strict deployment naming rules are enforced

### DIFF
--- a/saw/recommendationswebapp/core/Manifest.xml
+++ b/saw/recommendationswebapp/core/Manifest.xml
@@ -2,6 +2,7 @@
 <Template>
   <Category>Solution</Category>
   <Title>Recommendations Solution</Title>
+  <IsLegacyTemplate>true</IsLegacyTemplate>  
   <Owners>
     <Owner displayname="Recommendations" email="mlapi@microsoft.com"/>
     <Owner displayname="Nati Nimni" email="natinimn@microsoft.com" />


### PR DESCRIPTION
Added islegacytemplate flag to manifest to ensure deployment naming rules with 3 to 9 alphanum chars are enforced. This is required because the arm templates in this solution occasionally use the resource group name as a prefix for other less lenient (from a naming perspective) resource providers which would cause the deployment to fail.